### PR TITLE
make days abbreviation like the native gnome calendar ones

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -25,7 +25,7 @@ function Calendar() {
 }
 
 Calendar.prototype = {
-    weekdayAbbr: ['س', 'ا', 'ا', 'ث', 'ا', 'خ', 'ج'],
+    weekdayAbbr: ['س', 'ح', 'ن', 'ث', 'ر', 'خ', 'ج'],
     _weekStart: 6,
 
     _init: function () {


### PR DESCRIPTION
This PR aims to make the days' abbreviations like the ones in the native gnome calendar.